### PR TITLE
feat: added `portalName`, `timeoutLength` and `...rest` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ export default () => {
 | verticalSpacing | number | No | 0 | Vertical spacing of the popup from the relative element |
 | safeAreaInsets | EdgeInsets | No | 0 | Safe area insets to use in positioning calculations. |
 | onClose | function | No | null | A callback that fired when user presses outside of the popup |
+| portalName | string | No | undefined | Provide a `PortalHost` `name` to target if you need to customize the location of the popup content. |
+| timeoutLength | number | No | 100 | Customize the delay used when measuring the popup trigger and content elements. Can be useful if you experience jumping when the popup opens. |
+| ...rest | ViewProps | No | undefined | Any other props you pass will be applied to the `View` wrapping your popup content. |
 
 
 #### Usage

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -65,7 +65,7 @@ const Popup = ({
   const handleAnchorLayout = useCallback(() => {
     if (anchorRef.current) {
       const timer = setTimeout(() => {
-        if (isMounted()) {
+        if (anchorRef.current && isMounted()) {
           anchorRef.current!.measureInWindow((x, y, width, height) => {
             setAnchorLayout({
               x,
@@ -84,7 +84,7 @@ const Popup = ({
   const handleContentLayout = useCallback(() => {
     if (contentRef.current) {
       const timer = setTimeout(() => {
-        if (isMounted()) {
+        if (anchorRef.current && isMounted()) {
           contentRef.current!.measureInWindow((x, y, width, height) => {
             setContentLayout({
               x,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,7 +32,23 @@ export type PopupProps = {
   children: ReactChildren | any;
 
   overlay?: boolean;
+  /**
+   * Advanced: If you need to change the portal used to render the popup
+   * component, you can specify a portal name to both this component and an
+   * @gorhom/portal `PortalHost`. For example, if you need to use a popup within a
+   * react-native `Modal` component, the modal will probably cover your popup
+   * content. To solve this, you can place a named `PortalHost` inside the
+   * `Modal` and pass `portalName` with the same value to `Popup`.
+   */
+  portalName?: string;
   onClose: Function | any;
+  /**
+   * Advanced: The amount of time to delay before checking the layout of floating
+   * components. If you find the popup content is jumping around the screen
+   * after opening, you can try changing this number to delay the request to
+   * measure the layout of the menu and trigger elements.
+   */
+  timeoutLength?: number;
 };
 
 export type PopupChildrenProps = {


### PR DESCRIPTION
### What does this PR do?

- Added `portalName` to customize the `PortalHost` where popup content is
  placed.
- Added `timeoutLength` to customize the delay when measuring popup content.
- Pass `...rest` props to the `View` wrapping popup content.

#### `portalName`
I ran into an issue where using `Popup` in a React Native `Modal`, covered the popup content. In order to work around that issue, I added a named `PortalHost` to my modal and passed that name through the `Popup` component.

#### `timeoutLength`
I was running into issues wher the popup content was sometimes positioning itself at 0, 0. The root issue was that the initial layout measurements were happening before the content was rendered. To solve this I wrapped that initial `measureWindow` request in a timeout similar to the existing timeout used with the `Dimensions` event listener. I further allowed customizing the timeout for all 3 `measureWindow` requests.

#### `...rest`
For accessibility on web, I wanted to combine [Downshift.js](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#examples) with `Popup`. However, Downshift (and accessibility patterns on web), require Select, Tooltip, etc. contents to always be accessible in the DOM. I was mostly able to work around that by controlling the `overlay` prop. However, I also needed to configure the `pointerEvents` prop of the popup content so it would not block interactions below it. To resolve this, I apply any additional props to the `View` component wrapping the user's popup content.

I know this is a lot of changes for a single PR but I figured it would be easier for us both to handle everything in one PR rather than multiple. Let me know if you want me to break any of these changes out or remove any of them entirely.